### PR TITLE
Rework hmsg getters and setters so that returning memory the caller m…

### DIFF
--- a/examples/subrequest.cc
+++ b/examples/subrequest.cc
@@ -34,9 +34,8 @@ public:
                                        ns_hlx::resp &a_resp)
         {
                 // Get body of resp
-                char *l_buf = NULL;
-                uint64_t l_len;
-                a_resp.get_body_allocd(&l_buf, l_len);
+                const char *l_buf = a_resp.get_body();
+                uint64_t l_len = a_resp.get_body_len();
 
                 // Create length string
                 char l_len_str[64];
@@ -50,13 +49,6 @@ public:
 
                 // Queue
                 ns_hlx::queue_api_resp(*(a_subr.get_requester_hconn()), l_api_resp);
-
-                // Free memory
-                if(l_buf)
-                {
-                        free(l_buf);
-                        l_buf = NULL;
-                }
 
                 return 0;
         }

--- a/include/hlx/hlx.h
+++ b/include/hlx/hlx.h
@@ -401,12 +401,13 @@ public:
         virtual ~hmsg();
 
         // Getters
-        type_t get_type(void);
-        nbq *get_q(void);
-        char *get_body_allocd(char **ao_buf, uint64_t &ao_len);
-        kv_map_list_t *get_headers_allocd();
-        void get_headers(kv_map_list_t *ao_headers);
-        uint64_t get_idx(void);
+        type_t get_type(void) const;
+        nbq *get_q(void) const;
+        const char *get_body();
+        uint64_t get_body_len() const;
+        void get_headers(kv_map_list_t *ao_headers) const;
+        const kv_map_list_t &get_headers();
+        uint64_t get_idx(void) const;
         void set_idx(uint64_t a_idx);
 
         // Setters
@@ -443,6 +444,11 @@ protected:
         type_t m_type;
         nbq *m_q;
         uint64_t m_idx;
+
+        // populated on demand by getters
+        kv_map_list_t *m_headers;
+        char *m_body;
+        uint64_t m_body_len;
 
 private:
         // -------------------------------------------------

--- a/src/phurl/phurl.cc
+++ b/src/phurl/phurl.cc
@@ -2017,9 +2017,8 @@ std::string dump_all_responses_line_dl(phurl_resp_list_t &a_resp_list,
                 {
                         if(l_fbf) {ARESP(", "); l_fbf = false;}
                         //NDBG_PRINT("RESPONSE SIZE: %ld\n", (*i_rx)->m_response_body.length());
-                        char *l_body_buf = NULL;
-                        uint64_t l_body_len = 0;
-                        l_resp->get_body_allocd(&l_body_buf, l_body_len);
+                        const char *l_body_buf = l_resp->get_body();
+                        uint64_t l_body_len = l_resp->get_body_len();
                         if(l_body_len)
                         {
                                 sprintf(l_buf, "\"%sbody%s\": %s",
@@ -2030,11 +2029,6 @@ std::string dump_all_responses_line_dl(phurl_resp_list_t &a_resp_list,
                         {
                                 sprintf(l_buf, "\"%sbody%s\": \"NO_RESPONSE\"",
                                                 l_body_color.c_str(), l_off_color.c_str());
-                        }
-                        if(l_body_buf)
-                        {
-                                free(l_body_buf);
-                                l_body_buf = NULL;
                         }
                         ARESP(l_buf);
                         l_fbf = true;
@@ -2119,11 +2113,11 @@ std::string dump_all_responses_json(phurl_resp_list_t &a_resp_list, int a_part_m
                 }
 
                 // Headers
-                ns_hlx::kv_map_list_t *l_headers = l_resp->get_headers_allocd();
+                const ns_hlx::kv_map_list_t &l_headers = l_resp->get_headers();
                 if(a_part_map & PART_HEADERS)
                 {
-                        for(ns_hlx::kv_map_list_t::const_iterator i_header = l_headers->begin();
-                            i_header != l_headers->end();
+                        for(ns_hlx::kv_map_list_t::const_iterator i_header = l_headers.begin();
+                            i_header != l_headers.end();
                             ++i_header)
                         {
                                 for(ns_hlx::str_list_t::const_iterator i_val = i_header->second.begin();
@@ -2156,8 +2150,8 @@ std::string dump_all_responses_json(phurl_resp_list_t &a_resp_list, int a_part_m
 
                 // Search for json
                 bool l_content_type_json = false;
-                ns_hlx::kv_map_list_t::const_iterator i_h = l_headers->find("Content-type");
-                if(i_h != l_headers->end())
+                ns_hlx::kv_map_list_t::const_iterator i_h = l_headers.find("Content-type");
+                if(i_h != l_headers.end())
                 {
                         for(ns_hlx::str_list_t::const_iterator i_val = i_h->second.begin();
                             i_val != i_h->second.end();
@@ -2175,9 +2169,8 @@ std::string dump_all_responses_json(phurl_resp_list_t &a_resp_list, int a_part_m
                 {
 
                         //NDBG_PRINT("RESPONSE SIZE: %ld\n", (*i_rx)->m_response_body.length());
-                        char *l_body_buf = NULL;
-                        uint64_t l_body_len = 0;
-                        l_resp->get_body_allocd(&l_body_buf, l_body_len);
+                        const char *l_body_buf = l_resp->get_body();
+                        uint64_t l_body_len = l_resp->get_body_len();
                         if(l_body_len)
                         {
                                 // Append json
@@ -2199,20 +2192,10 @@ std::string dump_all_responses_json(phurl_resp_list_t &a_resp_list, int a_part_m
                         {
                                 JS_ADD_MEMBER("body", "NO_RESPONSE");
                         }
-                        if(l_body_buf)
-                        {
-                                free(l_body_buf);
-                                l_body_buf = NULL;
-                        }
                 }
 
                 l_js_array.PushBack(l_obj, l_js_allocator);
 
-                if(l_headers)
-                {
-                        delete l_headers;
-                        l_headers = NULL;
-                }
         }
 
         // TODO -Can I just create an array -do I have to stick in a document?


### PR DESCRIPTION
…ust free is not required.

Keep the get_headers that populates an existing object because someone might have an existing object they wish to reuse for performance reasons